### PR TITLE
Fix Book Covers on Tinted / Clear Widgets

### DIFF
--- a/ReadingProgressWidget/WidgetViews.swift
+++ b/ReadingProgressWidget/WidgetViews.swift
@@ -21,6 +21,7 @@ struct SmallWidgetView: View {
                        let uiImage = UIImage(data: imageData) {
                         Image(uiImage: uiImage)
                             .resizable()
+                            .widgetAccentedRenderingMode(.fullColor)
                             .aspectRatio(contentMode: .fill)
                             .frame(width: 65, height: 88)
                             .clipped()
@@ -214,6 +215,7 @@ struct LargeBookProgressRow: View {
             if let imageData = book.coverImageData, let uiImage = UIImage(data: imageData) {
                 Image(uiImage: uiImage)
                     .resizable()
+                    .widgetAccentedRenderingMode(.fullColor)
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 45, height: 60)
                     .clipped()
@@ -321,6 +323,7 @@ struct MediumBookProgressRow: View {
             if let imageData = book.coverImageData, let uiImage = UIImage(data: imageData) {
                 Image(uiImage: uiImage)
                     .resizable()
+                    .widgetAccentedRenderingMode(.fullColor)
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 48, height: 66)
                     .clipped()

--- a/ReleaseCountdownWidget.swift
+++ b/ReleaseCountdownWidget.swift
@@ -114,6 +114,7 @@ private struct SmallReleaseView: View {
             if let data = item?.coverImageData, let ui = UIImage(data: data) {
                 Image(uiImage: ui)
                     .resizable()
+                    .widgetAccentedRenderingMode(.fullColor)
                     .aspectRatio(contentMode: .fill)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .clipped()
@@ -187,6 +188,7 @@ private struct MediumReleaseListView: View {
                         if let data = item.coverImageData, let ui = UIImage(data: data) {
                             Image(uiImage: ui)
                                 .resizable()
+                                .widgetAccentedRenderingMode(.fullColor)
                                 .aspectRatio(contentMode: .fill)
                                 .frame(width: 40, height: 56)
                                 .clipped()
@@ -260,6 +262,7 @@ private struct LargeReleaseListView: View {
                             if let data = item.coverImageData, let ui = UIImage(data: data) {
                                 Image(uiImage: ui)
                                     .resizable()
+                                    .widgetAccentedRenderingMode(.fullColor)
                                     .aspectRatio(contentMode: .fill)
                                     .frame(width: 44, height: 62)
                                     .clipped()


### PR DESCRIPTION
Addresses: https://github.com/komadorirobin/Softcover/issues/4

iOS 18 (Tinted Homescreen) and iOS 26 Clear Home Screen by default will render any images as blank white.

`.widgetAccentedRenderingMode(.fullColor)` is required to get the widgets to render images in colour. 

I believe I have updated all relevant image components within the widgets
| Before | After |
|--------|-------|
|  <img width="1260" height="2736" alt="Simulator Screenshot - iPhone Air - 2025-11-11 at 22 52 54" src="https://github.com/user-attachments/assets/8b360283-e679-41cd-884d-7f9b9ef51783" /> | <img width="1260" height="2736" alt="Simulator Screenshot - iPhone Air - 2025-11-11 at 22 49 04" src="https://github.com/user-attachments/assets/1d205c8d-2081-47ee-b8e6-d06a47404011" /> |